### PR TITLE
feat(seo): setup metadata, sitemap, robots and noindex for private pages

### DIFF
--- a/app/about-us/page.tsx
+++ b/app/about-us/page.tsx
@@ -1,17 +1,6 @@
-import { Metadata } from "next";
 import { routes } from "@/src/constants/routes";
+import { buildPublicMetadata } from "@/src/constants/seo";
 
-export const metadata: Metadata = {
-  title: routes.ABOUT_US.metaTitle,
-  description: routes.ABOUT_US.description,
-  openGraph: {
-    title: routes.ABOUT_US.metaTitle,
-    description: routes.ABOUT_US.description,
-    url: routes.ABOUT_US.path,
-  },
-  alternates: {
-    canonical: routes.ABOUT_US.path,
-  },
-};
+export const metadata = buildPublicMetadata(routes.ABOUT_US);
 
 export { default } from "@/src/containers/about-us";

--- a/app/admin/account-setting/page.tsx
+++ b/app/admin/account-setting/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   alternates: {
     canonical: adminRoutes.ACCOUNT_SETTING.path,
   },
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: { index: false, follow: false },
+  },
 };
 
 export { default } from "@/src/containers/admin/account-setting";

--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   alternates: {
     canonical: adminRoutes.ORDERS.path,
   },
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: { index: false, follow: false },
+  },
 };
 
 export { default } from "@/src/containers/admin/order-history";

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -14,6 +14,11 @@ export const metadata: Metadata = {
   alternates: {
     canonical: adminRoutes.DASHBOARD.path,
   },
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: { index: false, follow: false },
+  },
 };
 
 export default function AdminDashboardPage() {

--- a/app/admin/payment-history/page.tsx
+++ b/app/admin/payment-history/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   alternates: {
     canonical: adminRoutes.PAYMENT_HISTORY.path,
   },
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: { index: false, follow: false },
+  },
 };
 
 export { default } from "@/src/containers/admin/payment-history";

--- a/app/admin/payment-method/page.tsx
+++ b/app/admin/payment-method/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   alternates: {
     canonical: adminRoutes.PAYMENT_METHOD.path,
   },
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: { index: false, follow: false },
+  },
 };
 
 export { default } from "@/src/containers/admin/payment-method";

--- a/app/admin/pending-payments/page.tsx
+++ b/app/admin/pending-payments/page.tsx
@@ -1,1 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Pending Payments | Legacy Forge",
+  description: "Review pending payments awaiting reconciliation.",
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: { index: false, follow: false },
+  },
+};
+
 export { default } from "@/src/containers/admin/pending-payments";

--- a/app/admin/pending-payments/page.tsx
+++ b/app/admin/pending-payments/page.tsx
@@ -1,13 +1,9 @@
 import type { Metadata } from "next";
+import { internalRoutes, noindexRobots } from "@/src/constants/internalRoutes";
 
 export const metadata: Metadata = {
-  title: "Pending Payments | Legacy Forge",
-  description: "Review pending payments awaiting reconciliation.",
-  robots: {
-    index: false,
-    follow: false,
-    googleBot: { index: false, follow: false },
-  },
+  ...internalRoutes.ADMIN_PENDING_PAYMENTS,
+  robots: noindexRobots,
 };
 
 export { default } from "@/src/containers/admin/pending-payments";

--- a/app/admin/quotes/page.tsx
+++ b/app/admin/quotes/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   alternates: {
     canonical: adminRoutes.QUOTES.path,
   },
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: { index: false, follow: false },
+  },
 };
 
 export { default } from "@/src/containers/admin/quotes";

--- a/app/admin/transaction-history/page.tsx
+++ b/app/admin/transaction-history/page.tsx
@@ -1,4 +1,15 @@
+import type { Metadata } from "next";
 import AdminTransactionHistory from "@/src/containers/admin/transaction-history";
+
+export const metadata: Metadata = {
+  title: "Transaction History | Legacy Forge",
+  description: "Review the full transaction history across all accounts.",
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: { index: false, follow: false },
+  },
+};
 
 export default function TransactionHistoryPage() {
   return <AdminTransactionHistory />;

--- a/app/admin/transaction-history/page.tsx
+++ b/app/admin/transaction-history/page.tsx
@@ -1,14 +1,10 @@
 import type { Metadata } from "next";
+import { internalRoutes, noindexRobots } from "@/src/constants/internalRoutes";
 import AdminTransactionHistory from "@/src/containers/admin/transaction-history";
 
 export const metadata: Metadata = {
-  title: "Transaction History | Legacy Forge",
-  description: "Review the full transaction history across all accounts.",
-  robots: {
-    index: false,
-    follow: false,
-    googleBot: { index: false, follow: false },
-  },
+  ...internalRoutes.ADMIN_TRANSACTION_HISTORY,
+  robots: noindexRobots,
 };
 
 export default function TransactionHistoryPage() {

--- a/app/blogs/page.tsx
+++ b/app/blogs/page.tsx
@@ -1,17 +1,6 @@
-import { Metadata } from "next";
 import { routes } from "@/src/constants/routes";
+import { buildPublicMetadata } from "@/src/constants/seo";
 
-export const metadata: Metadata = {
-  title: routes.BLOGS.metaTitle,
-  description: routes.BLOGS.description,
-  openGraph: {
-    title: routes.BLOGS.metaTitle,
-    description: routes.BLOGS.description,
-    url: routes.BLOGS.path,
-  },
-  alternates: {
-    canonical: routes.BLOGS.path,
-  },
-};
+export const metadata = buildPublicMetadata(routes.BLOGS);
 
 export { default } from "@/src/containers/blogs";

--- a/app/contact-us/page.tsx
+++ b/app/contact-us/page.tsx
@@ -1,17 +1,6 @@
-import { Metadata } from "next";
 import { routes } from "@/src/constants/routes";
+import { buildPublicMetadata } from "@/src/constants/seo";
 
-export const metadata: Metadata = {
-  title: routes.CONTACT_US.metaTitle,
-  description: routes.CONTACT_US.description,
-  openGraph: {
-    title: routes.CONTACT_US.metaTitle,
-    description: routes.CONTACT_US.description,
-    url: routes.CONTACT_US.path,
-  },
-  alternates: {
-    canonical: routes.CONTACT_US.path,
-  },
-};
+export const metadata = buildPublicMetadata(routes.CONTACT_US);
 
 export { default } from "@/src/containers/contact-us";

--- a/app/custom-shapes/page.tsx
+++ b/app/custom-shapes/page.tsx
@@ -1,17 +1,6 @@
-import { Metadata } from "next";
 import { routes } from "@/src/constants/routes";
+import { buildPublicMetadata } from "@/src/constants/seo";
 
-export const metadata: Metadata = {
-  title: routes.CUSTOM_SHAPES.metaTitle,
-  description: routes.CUSTOM_SHAPES.description,
-  openGraph: {
-    title: routes.CUSTOM_SHAPES.metaTitle,
-    description: routes.CUSTOM_SHAPES.description,
-    url: routes.CUSTOM_SHAPES.path,
-  },
-  alternates: {
-    canonical: routes.CUSTOM_SHAPES.path,
-  },
-};
+export const metadata = buildPublicMetadata(routes.CUSTOM_SHAPES);
 
 export { default } from "@/src/containers/custom-shapes";

--- a/app/dashboard/account-setting/page.tsx
+++ b/app/dashboard/account-setting/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   alternates: {
     canonical: routes.ACCOUNT_SETTING.path,
   },
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: { index: false, follow: false },
+  },
 };
 
 export { default } from "@/src/containers/account-setting";

--- a/app/dashboard/orders/page.tsx
+++ b/app/dashboard/orders/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   alternates: {
     canonical: routes.ORDERS.path,
   },
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: { index: false, follow: false },
+  },
 };
 
 export { default } from "@/src/containers/orders";

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -14,6 +14,11 @@ export const metadata: Metadata = {
   alternates: {
     canonical: routes.DASHBOARD.path,
   },
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: { index: false, follow: false },
+  },
 };
 
 export default function DashboardPage() {

--- a/app/dashboard/payment-history/page.tsx
+++ b/app/dashboard/payment-history/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   alternates: {
     canonical: routes.PAYMENT_HISTORY.path,
   },
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: { index: false, follow: false },
+  },
 };
 
 export { default } from "@/src/containers/payment-history";

--- a/app/dashboard/payment-method/page.tsx
+++ b/app/dashboard/payment-method/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   alternates: {
     canonical: routes.PAYMENT_METHOD.path,
   },
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: { index: false, follow: false },
+  },
 };
 
 export { default } from "@/src/containers/payment-method";

--- a/app/dashboard/quotes/page.tsx
+++ b/app/dashboard/quotes/page.tsx
@@ -12,6 +12,11 @@ export const metadata: Metadata = {
   alternates: {
     canonical: routes.QUOTES.path,
   },
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: { index: false, follow: false },
+  },
 };
 
 export { default } from "@/src/containers/quotes";

--- a/app/dashboard/tracking/page.tsx
+++ b/app/dashboard/tracking/page.tsx
@@ -1,13 +1,9 @@
 import type { Metadata } from "next";
+import { internalRoutes, noindexRobots } from "@/src/constants/internalRoutes";
 
 export const metadata: Metadata = {
-  title: "Tracking | Legacy Forge",
-  description: "Track your custom coin orders with Legacy Forge.",
-  robots: {
-    index: false,
-    follow: false,
-    googleBot: { index: false, follow: false },
-  },
+  ...internalRoutes.DASHBOARD_TRACKING,
+  robots: noindexRobots,
 };
 
 export default function TrackingPageDisabled() {

--- a/app/design-summary/page.tsx
+++ b/app/design-summary/page.tsx
@@ -1,17 +1,6 @@
-import { Metadata } from "next";
 import { routes } from "@/src/constants/routes";
+import { buildPublicMetadata } from "@/src/constants/seo";
 
-export const metadata: Metadata = {
-  title: routes.DESIGN_SUMMARY.metaTitle,
-  description: routes.DESIGN_SUMMARY.description,
-  openGraph: {
-    title: routes.DESIGN_SUMMARY.metaTitle,
-    description: routes.DESIGN_SUMMARY.description,
-    url: routes.DESIGN_SUMMARY.path,
-  },
-  alternates: {
-    canonical: routes.DESIGN_SUMMARY.path,
-  },
-};
+export const metadata = buildPublicMetadata(routes.DESIGN_SUMMARY);
 
 export { default } from "@/src/containers/design-summary";

--- a/app/design-team/page.tsx
+++ b/app/design-team/page.tsx
@@ -1,17 +1,6 @@
-import { Metadata } from "next";
 import { routes } from "@/src/constants/routes";
+import { buildPublicMetadata } from "@/src/constants/seo";
 
-export const metadata: Metadata = {
-  title: routes.DESIGN_TEAM.metaTitle,
-  description: routes.DESIGN_TEAM.description,
-  openGraph: {
-    title: routes.DESIGN_TEAM.metaTitle,
-    description: routes.DESIGN_TEAM.description,
-    url: routes.DESIGN_TEAM.path,
-  },
-  alternates: {
-    canonical: routes.DESIGN_TEAM.path,
-  },
-};
+export const metadata = buildPublicMetadata(routes.DESIGN_TEAM);
 
 export { default } from "@/src/containers/design-team";

--- a/app/drafts/[id]/edit/page.tsx
+++ b/app/drafts/[id]/edit/page.tsx
@@ -1,14 +1,10 @@
 import type { Metadata } from "next";
+import { internalRoutes, noindexRobots } from "@/src/constants/internalRoutes";
 import DraftEditPage from "@/src/containers/drafts/edit";
 
 export const metadata: Metadata = {
-  title: "Edit Draft | Legacy Forge",
-  description: "Edit your saved coin design draft.",
-  robots: {
-    index: false,
-    follow: false,
-    googleBot: { index: false, follow: false },
-  },
+  ...internalRoutes.DRAFT_EDIT,
+  robots: noindexRobots,
 };
 
 export default async function DraftEdit({

--- a/app/drafts/[id]/edit/page.tsx
+++ b/app/drafts/[id]/edit/page.tsx
@@ -1,12 +1,21 @@
-"use client";
-import React, { use } from "react";
+import type { Metadata } from "next";
 import DraftEditPage from "@/src/containers/drafts/edit";
 
-export default function DraftEdit({
+export const metadata: Metadata = {
+  title: "Edit Draft | Legacy Forge",
+  description: "Edit your saved coin design draft.",
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: { index: false, follow: false },
+  },
+};
+
+export default async function DraftEdit({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id } = use(params);
+  const { id } = await params;
   return <DraftEditPage draftId={id} />;
 }

--- a/app/drafts/[id]/page.tsx
+++ b/app/drafts/[id]/page.tsx
@@ -1,12 +1,21 @@
-"use client";
-import React, { use } from "react";
+import type { Metadata } from "next";
 import DraftDetailPage from "@/src/containers/drafts/detail";
 
-export default function DraftDetail({
+export const metadata: Metadata = {
+  title: "Draft Detail | Legacy Forge",
+  description: "Review the details of your saved coin design draft.",
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: { index: false, follow: false },
+  },
+};
+
+export default async function DraftDetail({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id } = use(params);
+  const { id } = await params;
   return <DraftDetailPage draftId={id} />;
 }

--- a/app/drafts/[id]/page.tsx
+++ b/app/drafts/[id]/page.tsx
@@ -1,14 +1,10 @@
 import type { Metadata } from "next";
+import { internalRoutes, noindexRobots } from "@/src/constants/internalRoutes";
 import DraftDetailPage from "@/src/containers/drafts/detail";
 
 export const metadata: Metadata = {
-  title: "Draft Detail | Legacy Forge",
-  description: "Review the details of your saved coin design draft.",
-  robots: {
-    index: false,
-    follow: false,
-    googleBot: { index: false, follow: false },
-  },
+  ...internalRoutes.DRAFT_DETAIL,
+  robots: noindexRobots,
 };
 
 export default async function DraftDetail({

--- a/app/drafts/page.tsx
+++ b/app/drafts/page.tsx
@@ -1,6 +1,15 @@
-"use client";
-import React from "react";
+import type { Metadata } from "next";
 import DraftsPage from "@/src/containers/drafts";
+
+export const metadata: Metadata = {
+  title: "Drafts | Legacy Forge",
+  description: "Manage your saved coin design drafts.",
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: { index: false, follow: false },
+  },
+};
 
 export default function Drafts() {
   return <DraftsPage />;

--- a/app/drafts/page.tsx
+++ b/app/drafts/page.tsx
@@ -1,14 +1,10 @@
 import type { Metadata } from "next";
+import { internalRoutes, noindexRobots } from "@/src/constants/internalRoutes";
 import DraftsPage from "@/src/containers/drafts";
 
 export const metadata: Metadata = {
-  title: "Drafts | Legacy Forge",
-  description: "Manage your saved coin design drafts.",
-  robots: {
-    index: false,
-    follow: false,
-    googleBot: { index: false, follow: false },
-  },
+  ...internalRoutes.DRAFTS,
+  robots: noindexRobots,
 };
 
 export default function Drafts() {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono, Cinzel } from "next/font/google";
 import "./globals.css";
 import Navbar from "@/src/components/common/layout/navbar/Navbar";
@@ -16,10 +16,62 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://www.legacyforge.com";
+
 export const metadata: Metadata = {
-  title: "Legacy Forge | Custom 3D Coins",
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: "Legacy Forge | Custom 3D Coins",
+    template: "%s | Legacy Forge",
+  },
   description:
     "Design and build your coins with Legacy Forge’s 3D builder. Preserve your legacy forever with custom-crafted coins.",
+  applicationName: "Legacy Forge",
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    type: "website",
+    siteName: "Legacy Forge",
+    url: "/",
+    title: "Legacy Forge | Custom 3D Coins",
+    description:
+      "Design and build your coins with Legacy Forge’s 3D builder. Preserve your legacy forever with custom-crafted coins.",
+    images: [
+      {
+        url: "/images/HeroCoin.png",
+        width: 1200,
+        height: 630,
+        alt: "Legacy Forge — Custom 3D Coins",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Legacy Forge | Custom 3D Coins",
+    description:
+      "Create personalized 3D coins with Legacy Forge’s online builder. Unique designs, premium materials, built to last.",
+    images: ["/images/HeroCoin.png"],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+      "max-video-preview": -1,
+    },
+  },
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 5,
+  themeColor: "#000000",
 };
 
 const cinzel = Cinzel({

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,16 +1,6 @@
-import { Metadata } from "next";
 import { routes } from "@/src/constants/routes";
-export const metadata: Metadata = {
-  title: routes.LOGIN.metaTitle,
-  description: routes.LOGIN.description,
-  openGraph: {
-    title: routes.LOGIN.metaTitle,
-    description: routes.LOGIN.description,
-    url: routes.LOGIN.path,
-  },
-  alternates: {
-    canonical: routes.LOGIN.path,
-  },
-};
-export { default } from "@/src/containers/login";
+import { buildPublicMetadata } from "@/src/constants/seo";
 
+export const metadata = buildPublicMetadata(routes.LOGIN);
+
+export { default } from "@/src/containers/login";

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,15 +1,6 @@
-import { Metadata } from "next";
 import { routes } from "@/src/constants/routes";
-export const metadata: Metadata = {
-  title: routes.HOME.metaTitle,
-  description: routes.HOME.description,
-  openGraph: {
-    title: routes.HOME.metaTitle,
-    description: routes.HOME.description,
-    url: routes.HOME.path,
-  },
-  alternates: {
-    canonical: routes.HOME.path,
-  },
-};
+import { buildPublicMetadata } from "@/src/constants/seo";
+
+export const metadata = buildPublicMetadata(routes.HOME);
+
 export { default } from "@/src/containers/home";

--- a/app/payment/layout.tsx
+++ b/app/payment/layout.tsx
@@ -1,12 +1,9 @@
 import type { Metadata } from "next";
+import { internalRoutes, noindexRobots } from "@/src/constants/internalRoutes";
 
 export const metadata: Metadata = {
-  title: "Payment | Legacy Forge",
-  robots: {
-    index: false,
-    follow: false,
-    googleBot: { index: false, follow: false },
-  },
+  ...internalRoutes.PAYMENT,
+  robots: noindexRobots,
 };
 
 export default function PaymentLayout({

--- a/app/payment/layout.tsx
+++ b/app/payment/layout.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Tracking | Legacy Forge",
-  description: "Track your custom coin orders with Legacy Forge.",
+  title: "Payment | Legacy Forge",
   robots: {
     index: false,
     follow: false,
@@ -10,6 +9,10 @@ export const metadata: Metadata = {
   },
 };
 
-export default function TrackingPageDisabled() {
-  return null;
+export default function PaymentLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
 }

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,17 +1,6 @@
-import { Metadata } from "next";
 import { routes } from "@/src/constants/routes";
+import { buildPublicMetadata } from "@/src/constants/seo";
 
-export const metadata: Metadata = {
-  title: routes.PRICING.metaTitle,
-  description: routes.PRICING.description,
-  openGraph: {
-    title: routes.PRICING.metaTitle,
-    description: routes.PRICING.description,
-    url: routes.PRICING.path,
-  },
-  alternates: {
-    canonical: routes.PRICING.path,
-  },
-};
+export const metadata = buildPublicMetadata(routes.PRICING);
 
 export { default } from "@/src/containers/pricing";

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,33 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://www.legacyforge.com";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: [
+          "/admin",
+          "/admin/",
+          "/dashboard",
+          "/dashboard/",
+          "/drafts",
+          "/drafts/",
+          "/payment",
+          "/payment/",
+          "/settings",
+          "/settings/",
+          "/api/",
+          "/login",
+          "/signup",
+          "/design-summary",
+        ],
+      },
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,17 +1,6 @@
-import { Metadata } from "next";
 import { routes } from "@/src/constants/routes";
+import { buildPublicMetadata } from "@/src/constants/seo";
 
-export const metadata: Metadata = {
-  title: routes.SERVICES.metaTitle,
-  description: routes.SERVICES.description,
-  openGraph: {
-    title: routes.SERVICES.metaTitle,
-    description: routes.SERVICES.description,
-    url: routes.SERVICES.path,
-  },
-  alternates: {
-    canonical: routes.SERVICES.path,
-  },
-};
+export const metadata = buildPublicMetadata(routes.SERVICES);
 
 export { default } from "@/src/containers/services";

--- a/app/settings/layout.tsx
+++ b/app/settings/layout.tsx
@@ -1,12 +1,9 @@
 import type { Metadata } from "next";
+import { internalRoutes, noindexRobots } from "@/src/constants/internalRoutes";
 
 export const metadata: Metadata = {
-  title: "Settings | Legacy Forge",
-  robots: {
-    index: false,
-    follow: false,
-    googleBot: { index: false, follow: false },
-  },
+  ...internalRoutes.SETTINGS,
+  robots: noindexRobots,
 };
 
 export default function SettingsLayout({

--- a/app/settings/layout.tsx
+++ b/app/settings/layout.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Tracking | Legacy Forge",
-  description: "Track your custom coin orders with Legacy Forge.",
+  title: "Settings | Legacy Forge",
   robots: {
     index: false,
     follow: false,
@@ -10,6 +9,10 @@ export const metadata: Metadata = {
   },
 };
 
-export default function TrackingPageDisabled() {
-  return null;
+export default function SettingsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
 }

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,17 +1,6 @@
-import { Metadata } from "next";
 import { routes } from "@/src/constants/routes";
+import { buildPublicMetadata } from "@/src/constants/seo";
 
-export const metadata: Metadata = {
-  title: routes.SIGNUP.metaTitle,
-  description: routes.SIGNUP.description,
-  openGraph: {
-    title: routes.SIGNUP.metaTitle,
-    description: routes.SIGNUP.description,
-    url: routes.SIGNUP.path,
-  },
-  alternates: {
-    canonical: routes.SIGNUP.path,
-  },
-};
+export const metadata = buildPublicMetadata(routes.SIGNUP);
 
 export { default } from "@/src/containers/signup";

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -18,11 +18,6 @@ const PUBLIC_PATHS: Array<{
   { path: "/custom-shapes", changeFrequency: "monthly", priority: 0.9 },
   { path: "/standard-builder", changeFrequency: "monthly", priority: 0.9 },
   {
-    path: "/standard-builder/dimensions",
-    changeFrequency: "monthly",
-    priority: 0.6,
-  },
-  {
     path: "/standard-builder/material",
     changeFrequency: "monthly",
     priority: 0.6,

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,65 @@
+import type { MetadataRoute } from "next";
+
+const SITE_URL =
+  process.env.NEXT_PUBLIC_SITE_URL ?? "https://www.legacyforge.com";
+
+const PUBLIC_PATHS: Array<{
+  path: string;
+  changeFrequency: MetadataRoute.Sitemap[number]["changeFrequency"];
+  priority: number;
+}> = [
+  { path: "/", changeFrequency: "weekly", priority: 1.0 },
+  { path: "/about-us", changeFrequency: "monthly", priority: 0.7 },
+  { path: "/services", changeFrequency: "monthly", priority: 0.8 },
+  { path: "/pricing", changeFrequency: "monthly", priority: 0.9 },
+  { path: "/contact-us", changeFrequency: "yearly", priority: 0.6 },
+  { path: "/blogs", changeFrequency: "weekly", priority: 0.7 },
+  { path: "/design-team", changeFrequency: "monthly", priority: 0.8 },
+  { path: "/custom-shapes", changeFrequency: "monthly", priority: 0.9 },
+  { path: "/standard-builder", changeFrequency: "monthly", priority: 0.9 },
+  {
+    path: "/standard-builder/dimensions",
+    changeFrequency: "monthly",
+    priority: 0.6,
+  },
+  {
+    path: "/standard-builder/material",
+    changeFrequency: "monthly",
+    priority: 0.6,
+  },
+  {
+    path: "/standard-builder/edge-type",
+    changeFrequency: "monthly",
+    priority: 0.6,
+  },
+  {
+    path: "/standard-builder/text-rings",
+    changeFrequency: "monthly",
+    priority: 0.6,
+  },
+  {
+    path: "/standard-builder/artwork",
+    changeFrequency: "monthly",
+    priority: 0.6,
+  },
+  {
+    path: "/standard-builder/packaging",
+    changeFrequency: "monthly",
+    priority: 0.6,
+  },
+  {
+    path: "/standard-builder/confirm-packaging",
+    changeFrequency: "monthly",
+    priority: 0.5,
+  },
+];
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+  return PUBLIC_PATHS.map(({ path, changeFrequency, priority }) => ({
+    url: `${SITE_URL}${path}`,
+    lastModified,
+    changeFrequency,
+    priority,
+  }));
+}

--- a/app/standard-builder/artwork/page.tsx
+++ b/app/standard-builder/artwork/page.tsx
@@ -1,17 +1,6 @@
-import { Metadata } from "next";
 import { routes } from "@/src/constants/routes";
+import { buildPublicMetadata } from "@/src/constants/seo";
 
-export const metadata: Metadata = {
-  title: routes.ARTWORK.metaTitle,
-  description: routes.ARTWORK.description,
-  openGraph: {
-    title: routes.ARTWORK.metaTitle,
-    description: routes.ARTWORK.description,
-    url: routes.ARTWORK.path,
-  },
-  alternates: {
-    canonical: routes.ARTWORK.path,
-  },
-};
+export const metadata = buildPublicMetadata(routes.ARTWORK);
 
 export { default } from "@/src/containers/standard-builder/art-work";

--- a/app/standard-builder/confirm-packaging/page.tsx
+++ b/app/standard-builder/confirm-packaging/page.tsx
@@ -1,17 +1,6 @@
-import { Metadata } from "next";
 import { routes } from "@/src/constants/routes";
+import { buildPublicMetadata } from "@/src/constants/seo";
 
-export const metadata: Metadata = {
-  title: routes.CONFIRM_PACKAGING.metaTitle,
-  description: routes.CONFIRM_PACKAGING.description,
-  openGraph: {
-    title: routes.CONFIRM_PACKAGING.metaTitle,
-    description: routes.CONFIRM_PACKAGING.description,
-    url: routes.CONFIRM_PACKAGING.path,
-  },
-  alternates: {
-    canonical: routes.CONFIRM_PACKAGING.path,
-  },
-};
+export const metadata = buildPublicMetadata(routes.CONFIRM_PACKAGING);
 
 export { default } from "@/src/containers/standard-builder/confirm-packaging";

--- a/app/standard-builder/edge-type/page.tsx
+++ b/app/standard-builder/edge-type/page.tsx
@@ -1,17 +1,6 @@
-import { Metadata } from "next";
 import { routes } from "@/src/constants/routes";
+import { buildPublicMetadata } from "@/src/constants/seo";
 
-export const metadata: Metadata = {
-  title: routes.EDGE_TYPE.metaTitle,
-  description: routes.EDGE_TYPE.description,
-  openGraph: {
-    title: routes.EDGE_TYPE.metaTitle,
-    description: routes.EDGE_TYPE.description,
-    url: routes.EDGE_TYPE.path,
-  },
-  alternates: {
-    canonical: routes.EDGE_TYPE.path,
-  },
-};
+export const metadata = buildPublicMetadata(routes.EDGE_TYPE);
 
 export { default } from "@/src/containers/standard-builder/edge-type";

--- a/app/standard-builder/material/page.tsx
+++ b/app/standard-builder/material/page.tsx
@@ -1,17 +1,6 @@
-import { Metadata } from "next";
 import { routes } from "@/src/constants/routes";
+import { buildPublicMetadata } from "@/src/constants/seo";
 
-export const metadata: Metadata = {
-  title: routes.MATERIAL.metaTitle,
-  description: routes.MATERIAL.description,
-  openGraph: {
-    title: routes.MATERIAL.metaTitle,
-    description: routes.MATERIAL.description,
-    url: routes.MATERIAL.path,
-  },
-  alternates: {
-    canonical: routes.MATERIAL.path,
-  },
-};
+export const metadata = buildPublicMetadata(routes.MATERIAL);
 
 export { default } from "@/src/containers/standard-builder/material";

--- a/app/standard-builder/packaging/page.tsx
+++ b/app/standard-builder/packaging/page.tsx
@@ -1,17 +1,6 @@
-import { Metadata } from "next";
 import { routes } from "@/src/constants/routes";
+import { buildPublicMetadata } from "@/src/constants/seo";
 
-export const metadata: Metadata = {
-  title: routes.PACKAGING.metaTitle,
-  description: routes.PACKAGING.description,
-  openGraph: {
-    title: routes.PACKAGING.metaTitle,
-    description: routes.PACKAGING.description,
-    url: routes.PACKAGING.path,
-  },
-  alternates: {
-    canonical: routes.PACKAGING.path,
-  },
-};
+export const metadata = buildPublicMetadata(routes.PACKAGING);
 
 export { default } from "@/src/containers/standard-builder/packaging";

--- a/app/standard-builder/page.tsx
+++ b/app/standard-builder/page.tsx
@@ -1,17 +1,6 @@
-import { Metadata } from "next";
 import { routes } from "@/src/constants/routes";
+import { buildPublicMetadata } from "@/src/constants/seo";
 
-export const metadata: Metadata = {
-  title: routes.STANDARD.metaTitle,
-  description: routes.STANDARD.description,
-  openGraph: {
-    title: routes.STANDARD.metaTitle,
-    description: routes.STANDARD.description,
-    url: routes.STANDARD.path,
-  },
-  alternates: {
-    canonical: routes.STANDARD.path,
-  },
-};
+export const metadata = buildPublicMetadata(routes.STANDARD);
 
 export { default } from "@/src/containers/standard-builder/dimensions";

--- a/app/standard-builder/text-rings/page.tsx
+++ b/app/standard-builder/text-rings/page.tsx
@@ -1,17 +1,6 @@
-import { Metadata } from "next";
 import { routes } from "@/src/constants/routes";
+import { buildPublicMetadata } from "@/src/constants/seo";
 
-export const metadata: Metadata = {
-  title: routes.TEXT_RINGS.metaTitle,
-  description: routes.TEXT_RINGS.description,
-  openGraph: {
-    title: routes.TEXT_RINGS.metaTitle,
-    description: routes.TEXT_RINGS.description,
-    url: routes.TEXT_RINGS.path,
-  },
-  alternates: {
-    canonical: routes.TEXT_RINGS.path,
-  },
-};
+export const metadata = buildPublicMetadata(routes.TEXT_RINGS);
 
 export { default } from "@/src/containers/standard-builder/text-rings";

--- a/src/constants/internalRoutes.ts
+++ b/src/constants/internalRoutes.ts
@@ -1,0 +1,75 @@
+import type { Metadata } from "next";
+
+export const noindexRobots: Metadata["robots"] = {
+  index: false,
+  follow: false,
+  googleBot: { index: false, follow: false },
+};
+
+export const internalRoutes = {
+  DRAFTS: {
+    title: "Drafts | Legacy Forge",
+    description:
+      "Your private workspace for in-progress coin designs. Save, revisit, and refine custom 3D coin concepts before placing an order with Legacy Forge. Drafts are tied to your account and are never shared publicly or shown in search results.",
+  },
+  DRAFT_DETAIL: {
+    title: "Draft Detail | Legacy Forge",
+    description:
+      "Review the full specifications of a saved coin design draft, including dimensions, materials, edge style, text rings, and artwork. Pick up exactly where you left off and move your custom coin closer to production.",
+  },
+  DRAFT_EDIT: {
+    title: "Edit Draft | Legacy Forge",
+    description:
+      "Continue editing your custom coin draft on Legacy Forge. Adjust dimensions, materials, edges, text rings, and artwork in our 3D builder before submitting your design for a quote or order.",
+  },
+  PAYMENT: {
+    title: "Payment | Legacy Forge",
+    description:
+      "Secure payment processing for Legacy Forge custom coin orders. This area handles checkout flows, payment confirmations, and integration callbacks, and is restricted to authenticated user sessions only.",
+  },
+  PAYMENT_CANCEL: {
+    title: "Payment Cancelled | Legacy Forge",
+    description:
+      "Your payment was cancelled before it could be completed. No charge was made. You can return to your quote at any time and finish checkout when you are ready to place your custom coin order.",
+  },
+  PAYMENT_SUCCESS: {
+    title: "Payment Successful | Legacy Forge",
+    description:
+      "Your payment has been received and your custom coin order has been confirmed. You will receive an email receipt with the next steps and a link to track production progress from your account dashboard.",
+  },
+  PAYMENT_QB_SUCCESS: {
+    title: "QuickBooks Connected | Legacy Forge",
+    description:
+      "Your QuickBooks account has been successfully connected to Legacy Forge. Invoices and payment records will now sync automatically so your accounting team always has up-to-date order data.",
+  },
+  PAYMENT_QB_ERROR: {
+    title: "QuickBooks Connection Failed | Legacy Forge",
+    description:
+      "We could not complete the QuickBooks connection for your Legacy Forge account. Review the error details, retry the connection, or contact support if the issue persists.",
+  },
+  SETTINGS: {
+    title: "Settings | Legacy Forge",
+    description:
+      "Manage account-level settings and integrations for Legacy Forge, including QuickBooks connection status, billing preferences, and other configuration options that apply across your account.",
+  },
+  SETTINGS_QUICKBOOKS: {
+    title: "QuickBooks Integration | Legacy Forge",
+    description:
+      "Manage your Legacy Forge QuickBooks integration. Connect, disconnect, or review the status of QuickBooks for invoice and payment syncing across your custom coin orders.",
+  },
+  ADMIN_PENDING_PAYMENTS: {
+    title: "Pending Payments | Legacy Forge Admin",
+    description:
+      "Internal admin view for monitoring pending payments across all Legacy Forge customers. Review payments awaiting reconciliation, identify stuck transactions, and take action before orders move into production.",
+  },
+  ADMIN_TRANSACTION_HISTORY: {
+    title: "Transaction History | Legacy Forge Admin",
+    description:
+      "Internal admin view of the complete transaction history across all Legacy Forge customer accounts. Audit payments, refunds, and QuickBooks sync activity for any time range.",
+  },
+  DASHBOARD_TRACKING: {
+    title: "Order Tracking | Legacy Forge",
+    description:
+      "Track the production and shipping progress of your custom Legacy Forge coin orders. View milestones from design approval through manufacturing, quality control, packaging, and final delivery.",
+  },
+} as const;

--- a/src/constants/seo.ts
+++ b/src/constants/seo.ts
@@ -1,0 +1,55 @@
+import type { Metadata } from "next";
+
+export const DEFAULT_OG_IMAGE = "/images/HeroCoin.png";
+export const DEFAULT_OG_IMAGE_WIDTH = 1200;
+export const DEFAULT_OG_IMAGE_HEIGHT = 630;
+export const SITE_NAME = "Legacy Forge";
+
+type PublicRouteEntry = {
+  metaTitle: string;
+  description: string;
+  path: string;
+  ogImage?: string;
+  twitter?: {
+    card?: "summary" | "summary_large_image" | "app" | "player";
+    title?: string;
+    description?: string;
+    image?: string;
+  };
+};
+
+export function buildPublicMetadata(route: PublicRouteEntry): Metadata {
+  const ogImage = route.ogImage ?? DEFAULT_OG_IMAGE;
+  const twitterImage = route.twitter?.image ?? ogImage;
+  const twitterTitle = route.twitter?.title ?? route.metaTitle;
+  const twitterDescription = route.twitter?.description ?? route.description;
+
+  return {
+    title: route.metaTitle,
+    description: route.description,
+    alternates: {
+      canonical: route.path,
+    },
+    openGraph: {
+      type: "website",
+      siteName: SITE_NAME,
+      url: route.path,
+      title: route.metaTitle,
+      description: route.description,
+      images: [
+        {
+          url: ogImage,
+          width: DEFAULT_OG_IMAGE_WIDTH,
+          height: DEFAULT_OG_IMAGE_HEIGHT,
+          alt: route.metaTitle,
+        },
+      ],
+    },
+    twitter: {
+      card: route.twitter?.card ?? "summary_large_image",
+      title: twitterTitle,
+      description: twitterDescription,
+      images: [twitterImage],
+    },
+  };
+}


### PR DESCRIPTION
- Added metadataBase and viewport in layout for absolute URLs
- Configured Open Graph and Twitter metadata for social previews
- Created sitemap with public routes
- Added robots.txt with restricted private paths
- Applied noindex to private/auth pages (admin, dashboard, payment, drafts, settings)
- Fixed missing metadata on multiple pages (unique titles/descriptions)
- Prevented indexing of non-public routes to avoid SEO conflicts

